### PR TITLE
Reworked the API's HTTP Responses 

### DIFF
--- a/API/classes/twitch_management.py
+++ b/API/classes/twitch_management.py
@@ -25,34 +25,34 @@ class twitch_management(object):
 
     def add(self):
         if(self.twitch_user_id == None):
-            return("Twitch username is invalid!")
+            return({"status":"error", "code":400, "message":"Twitch username is invalid!"})
 
         if(len(self.db.defined_select('unique_twitch_notification', [self.twitch_username, self.discord_channel_id])) != 0):
-            return("Notification already exist!")
+            return({"status":"error", "code":400, "message":"Notification already exist!"})
 
         subscribe_status = self.twitch.subscribe(self.twitch_user_id)
 
         if(subscribe_status == True):
             db_status        = self.db.defined_insert('add_twitch_notification', [self.twitch_username, self.twitch_user_id, self.discord_channel_id])
         else:
-            return("Error subscribing to twitch service!")
+            return({"status":"error", "code":503, "message":"Error subscribing to twitch service!"})
 
         if(db_status == True):
-            return("Notification successfully added!")
+            return({"status":"success", "code":200, "message":"Notification successfully added!"})
         else:
-            return("Error saving notifiaction to database!")
+            return({"status":"error", "code":503, "message":"Error saving notifiaction to database!"})
 
 
     def delete(self):
         if(self.twitch_user_id == None):
-            return("Twitch username is invalid!")
+            return({"status":"error", "code":400, "message":"Twitch username is invalid!"})
 
         db_status = self.db.defined_delete('delete_twitch_notification', [self.twitch_username, self.twitch_user_id, self.discord_channel_id])
 
         if(db_status == True):
-            return("Notification successfully removed!")
+            return({"status":"success", "code":200, "message":"Notification successfully removed!"})
         else:
-            return("Error removing notifiaction!")
+            return({"status":"error", "code":503, "message":"Error removing notifiaction!"})
 
 
 

--- a/API/classes/youtube/youtube_management.py
+++ b/API/classes/youtube/youtube_management.py
@@ -27,12 +27,12 @@ class youtube_management(object):
 
         # If the youtube_channel_id is unable to parse the URL, return the error.
         if yt_channel_id is None:
-            return("Error unable to parse the URL!")
+            return({"status":"error", "code":400, "message":"Error unable to parse the URL!"})
 
         # Check if the yt_channel_id and disc_channel_id combination are unqiue.
         if(self.check_if_exist(yt_channel_id, disc_channel_id)):
             # The subscription to the YouTube channel in the Discord channel already exist.
-            return("Notification already exist!")
+            return({"status":"error", "code":400, "message":"Notification already exist!"})
 
         # Add notifcation to local databse
         database_status = self.manage_databse_subscription("subscribe", yt_channel_id, disc_channel_id)
@@ -40,7 +40,7 @@ class youtube_management(object):
         # Check if the local database insertion
         if database_status is False:
             # Error with the database
-            return("Error internal database failure!")
+            return({"status":"error", "code":503, "message":"Error internal database failure!"})
 
         # Subscribe to the webhook for the given channel
         # # TODO: figure out timing issue
@@ -54,7 +54,7 @@ class youtube_management(object):
             # mechanism for handling this
             pass
 
-        return("Notification successfully added!")
+        return({"status":"success", "code":200, "message":"Notification successfully added!"})
 
     def unsubscribe(self, yt_channel_url, disc_channel_id):
         # Use the youtube_channel_id class to determine the YouTube channel ID
@@ -65,7 +65,7 @@ class youtube_management(object):
 
         # If the youtube_channel_id is unable to parse the URL, return the error.
         if yt_channel_id is None:
-            return("Error unable to parse the URL!")
+            return({"status":"error", "code":400, "message":"Error unable to parse the URL!"})
 
         # Remove the yt_channel and disc_channel_id combination from the database
         database_status = self.manage_databse_subscription("unsubscribe", yt_channel_id, disc_channel_id)
@@ -75,9 +75,9 @@ class youtube_management(object):
 
         if database_status == False:
             # TODO: Implement methodolgy of notifiying developers about this issue.
-            return("Error removing notification from the database!")
+            return({"status":"error", "code":503, "message":"Error removing notification from the database!"})
         else:
-            return("Notification successfully removed!")
+            return({"status":"success", "code":200, "message":"Notification successfully removed!"})
 
 
     def check_if_exist(self, yt_channel_id, disc_channel_id):

--- a/API/middleware/cors.py
+++ b/API/middleware/cors.py
@@ -25,4 +25,4 @@ class cors(object):
                 ('Access-Control-Max-Age', '86400'),  # 24 hours
             ))
 
-        resp.status = falcon.HTTP_OK
+            resp.status = falcon.HTTP_OK

--- a/API/routes/test.py
+++ b/API/routes/test.py
@@ -7,11 +7,9 @@ class test(object):
         pass
 
     def on_get(self, req, resp):
-        print(req.get_header('x-real-ip'))
-        print(req.headers)
-        resp.status = falcon.HTTP_200   # Set response type
+        resp.status = falcon.HTTP_200               # Set response type
         resp.content_type = ['application/json']    # Set content_type
-        resp.body = "Test successful"
+        resp.body = "Test successful"               # Set response body
 
     def on_post(self, req, resp):
         pass

--- a/API/routes/twitch/add.py
+++ b/API/routes/twitch/add.py
@@ -21,10 +21,22 @@ class twitch_add(object):
 
             # If twitch_username or discord_channel_id are not set then raise exception
             if(twitch_username == None or discord_channel_id == None):
-                raise falcon.HTTPBadRequest('Missing Requried Headers', 'Required headers: twitch_username and discord_channel_id')
+                raise falcon.HTTPBadRequest('Missing Requried Headers', 'Required headers: twitch-username and discord-channel-id')
 
             # Using twitch_management class attempt to add new notifiaction
-            resp.body = twitch_management(twitch_username, discord_channel_id).add()
-            
+            message = twitch_management(twitch_username, discord_channel_id).add()
+
+            resp.status = falcon.get_http_status(message['code'])
+            resp.content_type = ['application/json']
+            resp.body = json.dumps(message)
+
+
+        except falcon.HTTPBadRequest as e:
+            message = {"status":"error", "code":400, "message":e.description}
+            resp.status = falcon.get_http_status(message['code'])
+            resp.content_type = ['application/json']
+            resp.body = json.dumps(message)
+
         except Exception as e:
+            print(str(e))
             resp.body = "API ERROR"

--- a/API/routes/twitch/delete.py
+++ b/API/routes/twitch/delete.py
@@ -17,13 +17,24 @@ class twitch_delete(object):
         pass
 
     def on_get(self, req, resp):
-        # Retrieve twitch_username and discrod_channel_id from headers
-        twitch_username     = req.get_header('twitch-username')
-        discord_channel_id  = req.get_header('discord-channel-id')
+        try:
+            # Retrieve twitch_username and discrod_channel_id from headers
+            twitch_username     = req.get_header('twitch-username')
+            discord_channel_id  = req.get_header('discord-channel-id')
 
-        # If twitch_username or discord_channel_id are not set then raise exception
-        if(twitch_username == None or discord_channel_id == None):
-            raise falcon.HTTPBadRequest('Missing Requried Headers', 'Required headers: twitch_username and discord_channel_id')
+            # If twitch_username or discord_channel_id are not set then raise exception
+            if(twitch_username == None or discord_channel_id == None):
+                raise falcon.HTTPBadRequest('Missing Requried Headers', 'Required headers: twitch_username and discord_channel_id')
 
-        # Using twitch_management class attempt to add new notifiaction
-        resp.body = twitch_management(twitch_username, discord_channel_id).delete()
+            # Using twitch_management class attempt to add new notifiaction
+            message = twitch_management(twitch_username, discord_channel_id).delete()
+
+            resp.status = falcon.get_http_status(message['code'])
+            resp.content_type = ['application/json']
+            resp.body = json.dumps(message)
+
+        except falcon.HTTPBadRequest as e:
+            message = {"status":"error", "code":400, "message":e.description}
+            resp.status = falcon.get_http_status(message['code'])
+            resp.content_type = ['application/json']
+            resp.body = json.dumps(message)

--- a/API/routes/twitch/metrics.py
+++ b/API/routes/twitch/metrics.py
@@ -27,7 +27,7 @@ class twitch_metrics_username(object):
 
         resp.status = falcon.HTTP_200   # Set response type
         resp.content_type = ['application/json']    # Set content_type
-        resp.body = data
+        resp.body = json.dumps(data)
 
 
 class twitch_metrics_id(object):
@@ -40,4 +40,4 @@ class twitch_metrics_id(object):
 
         resp.status = falcon.HTTP_200   # Set response type
         resp.content_type = ['application/json']    # Set content_type
-        resp.body = data
+        resp.body = json.dumps(data)

--- a/API/routes/youtube/add.py
+++ b/API/routes/youtube/add.py
@@ -6,6 +6,7 @@
 # - /youtube/manage/add
 
 import falcon
+import json
 
 from middleware.auth import auth
 from classes.youtube.youtube_management import youtube_management
@@ -16,14 +17,24 @@ class youtube_add(object):
         pass
 
     def on_get(self, req, resp):
+        try:
+            # Retrieve the Discord channel ID and the YouTube channel URL from the headers
+            disc_channel_id  = req.get_header('discord-channel-id')
+            yt_channel_url   = req.get_header('youtube-channel-url')
 
-        # Retrieve the Discord channel ID and the YouTube channel URL from the headers
-        disc_channel_id  = req.get_header('discord-channel-id')
-        yt_channel_url   = req.get_header('youtube-channel-url')
+            # If either of the two required headers are missing, return bad request
+            if(disc_channel_id == None or yt_channel_url == None):
+                raise falcon.HTTPBadRequest('Missing Requried Headers', 'Required headers: discord-channel-id and youtube-channel-url')
 
-        # If either of the two required headers are missing, return bad request
-        if(disc_channel_id == None or yt_channel_url == None):
-            raise falcon.HTTPBadRequest('Missing Requried Headers', 'Required headers: discord_channel_id and youtube_channel_url')
+            # Using the youtube_management class add the subscription to the database
+            message = youtube_management().subscribe(yt_channel_url, disc_channel_id)
 
-        # Using the youtube_management class add the subscription to the database
-        resp.body = youtube_management().subscribe(yt_channel_url, disc_channel_id)
+            resp.status = falcon.get_http_status(message['code'])
+            resp.content_type = ['application/json']
+            resp.body = json.dumps(message)
+
+        except falcon.HTTPBadRequest as e:
+            message = {"status":"error", "code":400, "message":e.description}
+            resp.status = falcon.get_http_status(message['code'])
+            resp.content_type = ['application/json']
+            resp.body = json.dumps(message)

--- a/API/routes/youtube/delete.py
+++ b/API/routes/youtube/delete.py
@@ -6,6 +6,7 @@
 # - /youtube/manage/delete
 
 import falcon
+import json
 
 from middleware.auth import auth
 from classes.youtube.youtube_management import youtube_management
@@ -16,14 +17,24 @@ class youtube_delete(object):
         pass
 
     def on_get(self, req, resp):
+        try:
+            # Retrieve the Discord channel ID and the YouTube channel URL from the headers
+            disc_channel_id  = req.get_header('discord-channel-id')
+            yt_channel_url   = req.get_header('youtube-channel-url')
 
-        # Retrieve the Discord channel ID and the YouTube channel URL from the headers
-        disc_channel_id  = req.get_header('discord-channel-id')
-        yt_channel_url   = req.get_header('youtube-channel-url')
+            # If either of the two required headers are missing, return bad request
+            if(disc_channel_id == None or yt_channel_url == None):
+                raise falcon.HTTPBadRequest('Missing Requried Headers', 'Required headers: discord-channel-id and youtube-channel-url')
 
-        # If either of the two required headers are missing, return bad request
-        if(disc_channel_id == None or yt_channel_url == None):
-            raise falcon.HTTPBadRequest('Missing Requried Headers', 'Required headers: discord_channel_id and youtube_channel_url')
+            # Using the youtube_management class add the subscription to the database
+            message = youtube_management().unsubscribe(yt_channel_url, disc_channel_id)
 
-        # Using the youtube_management class add the subscription to the database
-        resp.body = youtube_management().unsubscribe(yt_channel_url, disc_channel_id)
+            resp.status = falcon.get_http_status(message['code'])
+            resp.content_type = ['application/json']
+            resp.body = json.dumps(message)
+
+        except falcon.HTTPBadRequest as e:
+            message = {"status":"error", "code":400, "message":e.description}
+            resp.status = falcon.get_http_status(message['code'])
+            resp.content_type = ['application/json']
+            resp.body = json.dumps(message)

--- a/discord_async/cogs/twitch.py
+++ b/discord_async/cogs/twitch.py
@@ -38,11 +38,12 @@ class twitch_cog(commands.Cog):
         elif(action in ['del', 'delete']):
             resp = requests.get(str(os.getenv('API_URL') + "/twitch/manage/delete"), headers=headers)
 
-        if(resp.status_code == 200):
-            await ctx.send(resp.text)
+        data = json.loads(resp.content)
+
+        if(data['message']):
+            await ctx.send(data['message'])
         else:
             await ctx.send('Back-end server error!')
-            # await ctx.send(resp.status_code)
 
 def setup(bot):
     bot.add_cog(twitch_cog(bot))

--- a/discord_async/cogs/twitch_history.py
+++ b/discord_async/cogs/twitch_history.py
@@ -25,7 +25,7 @@ class twitch_history_cog(commands.Cog):
 
         resp = requests.get(str(os.getenv('API_URL') + "/twitch/metrics/" + twitch_username))
 
-        data = json.loads(resp.text)
+        data = json.loads(resp.content)
 
         message = 'Time Metrics for the Last 10 Streams \nDate - - - - - Stream Length\n'
 

--- a/discord_async/cogs/youtube.py
+++ b/discord_async/cogs/youtube.py
@@ -37,10 +37,11 @@ class twitch_cog(commands.Cog):
         elif(action in ['del', 'delete']):
             resp = requests.get(str(os.getenv('API_URL').strip("\r") + "/youtube/manage/delete"), headers=headers)
 
-        if(resp.status_code == 200):
-            await ctx.send(resp.text)
+        data = json.loads(resp.content)
+
+        if(data['message']):
+            await ctx.send(data['message'])
         else:
-            print(resp.status_code)
             await ctx.send('Back-end server error!')
 
 


### PR DESCRIPTION
**Reworked the API's HTTP Responses**
Resolves #26

- Standardized and implemented uniform HTTP status codes across API routes.
- Implemented JSON based response content for API routes.
--  Example Structure: {"status":"error", "code":503, "message":"Error internal database failure!"}
- In an effort to segment the "classes" from the API: Classes will return an integer indicating the status code. The API routes then use the function "falcon.get_http_status()" to convert this into a falcon usable http status. https://falcon.readthedocs.io/en/stable/api/util.html#falcon.get_http_status
- Implemented and extended try/except blocks.

**Fixed Incorrect Indention**
This incorrect indention resulted in all request to the API returning an HTTP status code of 200 or OK.

**Updates Discord Module to Reflect API Changes**
Updated the discord commands that interface with the API to properly expect and handle the new JSON formatted data. Checking for the status code is not particularly important as the value in "message" is designed to inform the user of success or failure. In the event that "message" cannot be found in the response content, a generalized "Back-end server error!" will be returned.