### PR TITLE
Created Support for Retrieving a List of Notifications

### DIFF
--- a/API/classes/notifications.py
+++ b/API/classes/notifications.py
@@ -1,0 +1,47 @@
+# Author: @Travis-Owens
+# Date: 2021-01-12
+# Desc: Used to retreive a list of notifications by discord_channel_id
+
+from classes.data_handler import data_handler
+
+class notifications(object):
+    def __init__(self):
+        self.db = data_handler()
+
+    def get_twitch_notifications(self, discord_channel_id):
+        # Return format:
+        # [{'twitch_user_id':x,'twitch_username':y}, ... ]
+
+        # Get Twitch User IDs
+        sql  = "SELECT `twitch_user_id` FROM `twitch_notifications` WHERE `discord_channel_id` = %s"
+        twitch_user_ids = data_handler().select(sql, [discord_channel_id])
+
+        if(len(twitch_user_ids) == 0):
+            # No twitch notifications found for the discord_channel_id
+            return(None)
+
+        # Flatten the twitch_user_ids dict into a list
+        twitch_user_ids = list(map(lambda x : x['twitch_user_id'], twitch_user_ids))
+
+        # Get Twitch Usernames
+        sql = "SELECT `twitch_user_id`, `twitch_username` FROM `twitch_channels` WHERE `twitch_user_id` IN (%s)"
+        # Inserts a '%s' for each element in the twitch_user_ids list
+        sql = sql % ','.join(['%s'] * len(twitch_user_ids))
+
+        twitch_data = data_handler().select(sql, tuple(twitch_user_ids))
+
+        return(twitch_data)
+
+
+    def get_youtube_notifications(self, discord_channel_id):
+        # Return format:
+        # [{'youtube_channel_id':x}, ...]
+
+        # Get YouTube Channel IDs
+        sql = "SELECT `yt_channel_id` as 'youtube_channel_id' FROM `youtube` WHERE `disc_channel_id` = %s"
+        youtube_channel_ids = self.db.select(sql, [discord_channel_id])
+
+        if(len(youtube_channel_ids) == 0):
+            return(None)
+
+        return(youtube_channel_ids)

--- a/API/main.py
+++ b/API/main.py
@@ -26,7 +26,11 @@ from routes.youtube.callback import youtube_callback
 from routes.youtube.add      import youtube_add
 from routes.youtube.delete   import youtube_delete
 
+# Twitter API routes
 from routes.twitter.callback import twitter_callback
+
+# Notifications API routes
+from routes.notifications.notifications import get_notificaitons
 
 # Routes for web interface
 from routes.web.discord.auth_callback import discord_auth_callback
@@ -53,10 +57,11 @@ class public_facing_api(object):
             {'route':'/youtube/manage/add',     'class': youtube_add()},
             {'route':'/youtube/manage/delete',  'class': youtube_delete()},
             {'route':'/test',   'class': test()},
+            {'route':'/notifications',   'class': get_notificaitons()},
             {'route':'/twitter/callback', 'class': twitter_callback()},
-            {'route':'/', 'class':root()},
             {'route':'/v1/web/discord/auth/callback', 'class':discord_auth_callback()},
-            {'route':'/v1/web/discord/auth/validate', 'class':discord_auth_validate()}
+            {'route':'/v1/web/discord/auth/validate', 'class':discord_auth_validate()},
+            {'route':'/', 'class':root()},
 
         ]
 

--- a/API/routes/notifications/notifications.py
+++ b/API/routes/notifications/notifications.py
@@ -1,0 +1,52 @@
+# Author: @Travis-Owens
+# Date: 2021-01-12
+# Desc: Used to retreive a list of notifications by discord_channel_id
+
+import falcon
+import json
+
+from middleware.auth import auth
+from classes.notifications import notifications
+
+@falcon.before(auth())
+class get_notificaitons(object):
+    def __init__(self):
+        pass
+
+    def on_get(self, req, resp):
+
+        try:
+            # Check if discord-channel-id is in headers, if not return HTTPBadRequest
+            discord_channel_id =  req.get_header('discord-channel-id')
+            if discord_channel_id is None:
+                raise falcon.HTTPBadRequest('Missing Requried Headers', 'Required header(s): discord-channel-id')
+
+            # Create object for notificaions class, get notification data for twitch and youtube
+            # If no notifications are found, type None will be returned
+            notifications_obj = notifications()
+            twitch_notifications  = notifications_obj.get_twitch_notifications(discord_channel_id)
+            youtube_notifications = notifications_obj.get_youtube_notifications(discord_channel_id)
+
+            # Create dict with notification data
+            data = { discord_channel_id: {
+                        'twitch':twitch_notifications,
+                        'youtube':youtube_notifications
+                        }
+                   }
+
+            # Set http status to 200, set content_type to JSON, and convert the data dict into JSON
+            resp.status = falcon.get_http_status(200)
+            resp.content_type = ['application/json']
+            resp.body = json.dumps(data)
+
+        except falcon.HTTPBadRequest as e:
+            message = {"status":"error", "code":400, "message":e.description}
+            resp.status = falcon.get_http_status(message['code'])
+            resp.content_type = ['application/json']
+            resp.body = json.dumps(message)
+
+        except Exception as e:
+            message = {"status":"error", "code":400, "message":'API ERROR'}
+            resp.status = falcon.get_http_status(message['code'])
+            resp.content_type = ['application/json']
+            resp.body = json.dumps(message)

--- a/discord_async/cogs/list.py
+++ b/discord_async/cogs/list.py
@@ -23,9 +23,9 @@ class notification_list_cog(commands.Cog):
 
         # Define supported platforms
         platforms = ['twitch', 'youtube']
-        if platform is not None and platform.lower() in platforms:
+        if platform.lower() not in platforms:
             # If provided platform doesn't exist, revert to displaying all notifications
-            platfrom = None
+            platform = None
 
         # Route requires, headers auth and discord-channel-id
         headers = {
@@ -50,11 +50,11 @@ class notification_list_cog(commands.Cog):
         embed.set_author(name="KeshBotics Notifications", url="", icon_url="https://cdn.discordapp.com/avatars/532575955324239882/653f3b3749c3da11947a70881d675160.png")
 
         # Add field for Twitch Notifications
-        if(platform == 'twitch' or platform is None):
+        if(platform is None or platform.lower() == 'twitch' ):
             embed.add_field(name="Twitch", value=notification_strings().get_twitch_str(data[str(ctx.channel.id)]['twitch']), inline=False)
 
         # Add field for YouTube Notifications
-        if(platform == 'youtube' or platform is None):
+        if(platform is None or platform.lower() == 'youtube' ):
             embed.add_field(name="YouTube", value=notification_strings().get_youtube_str(data[str(ctx.channel.id)]['youtube']), inline=False)
 
         await ctx.send(content="", embed=embed)

--- a/discord_async/cogs/list.py
+++ b/discord_async/cogs/list.py
@@ -1,0 +1,98 @@
+# Author: @Travis-Owens
+# Date: 2021-01-12
+# Desc: This command is used to retrieve a list of notifications on a per
+#       discord channel basis
+
+import discord
+from discord.ext import commands
+
+import requests
+import json
+import os
+
+usage = os.getenv('COMMAND_PREFIX') + 'list <platform (Twitch/YouTube)>'
+
+class notification_list_cog(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command(usage=usage, description="Notification List", aliases=['notifications'])
+    @commands.has_permissions(manage_messages=True)
+    async def list(self, ctx, platform = None):
+        # NOTE: if platform is not provided (None), return notifications for all platforms
+
+        # Define supported platforms
+        platforms = ['twitch', 'youtube']
+        if platform is not None and platform.lower() in platforms:
+            # If provided platform doesn't exist, revert to displaying all notifications
+            platfrom = None
+
+        # Route requires, headers auth and discord-channel-id
+        headers = {
+                    'auth': os.getenv('API_AUTH_CODE').strip("\r"),
+                    'discord-channel-id': str(ctx.channel.id)
+                }
+
+        # Query notifications route of the API
+        resp = requests.get(str(os.getenv('API_URL').strip("\r") + '/notifications'), headers = headers)
+
+        # Ensure proper status code
+        if(resp.status_code != 200):
+            # Expected status code is 200
+            await ctx.send('Back-end server error!')
+            return
+
+        # Convert the JSON response to a python dictionary
+        data = json.loads(resp.content)
+
+        # Create embeded message
+        embed = discord.Embed(colour=discord.Colour(0xd06412))
+        embed.set_author(name="KeshBotics Notifications", url="", icon_url="https://cdn.discordapp.com/avatars/532575955324239882/653f3b3749c3da11947a70881d675160.png")
+
+        # Add field for Twitch Notifications
+        if(platform == 'twitch' or platform is None):
+            embed.add_field(name="Twitch", value=notification_strings().get_twitch_str(data[str(ctx.channel.id)]['twitch']), inline=False)
+
+        # Add field for YouTube Notifications
+        if(platform == 'youtube' or platform is None):
+            embed.add_field(name="YouTube", value=notification_strings().get_youtube_str(data[str(ctx.channel.id)]['youtube']), inline=False)
+
+        await ctx.send(content="", embed=embed)
+
+class notification_strings(object):
+    def __init__(self):
+        pass
+
+    def get_twitch_str(self, twitch_channels):
+        # Creates a list in string format
+        # Adds hyperlinks to the twitch_username (markup)
+
+        if twitch_channels is None:
+            return('No Twitch notifications found.\n\n')
+
+        twitch_str = ''
+        for channel in twitch_channels:
+            twitch_str += str("[" + channel['twitch_username'] + "](https://twitch.tv/" + channel['twitch_username'] + ")\n")
+
+        twitch_str += "Remove a Twitch notification: ```k!twitch del <twitch_username>```\n"
+        twitch_str += "\n\n\n"
+
+        return(twitch_str)
+
+    def get_youtube_str(self, youtube_channels):
+        # Creates a list in string format
+
+        if youtube_channels is None:
+            return('No YouTube notifications found.\n\n')
+
+        youtube_str = ''
+        for channel in youtube_channels:
+            youtube_str += str("https://youtube.com/channel/" + channel['youtube_channel_id'] + "\n")
+
+        youtube_str += "Remove a YouTube notification: ```k!youtube del <YouTube channel URL>```\n"
+        youtube_str += "\n\n"
+
+        return(youtube_str)
+
+def setup(bot):
+    bot.add_cog(notification_list_cog(bot))

--- a/discord_async/main.py
+++ b/discord_async/main.py
@@ -33,7 +33,8 @@ extensions = [  'cogs.owner',
                 'cogs.youtube',
                 'cogs.purge',
                 'cogs.error_handling',
-                'cogs.help'
+                'cogs.help',
+                'cogs.list'
                 ]
 
 # Load the cogs


### PR DESCRIPTION
Created support for retrieving a list of notifications sorted by platform (Twitch and YouTube).

API Route: '/notifications'
Discord Command: 'list' or 'notifications'

Example Return:

```
{
    discord_channel_id: {
        "youtube": [
            {
                "youtube_channel_id": UCX....
            }
        ],
        "twitch": [
            {
                "twitch_username": "twitch",
                "twitch_user_id": 12826
            },
            {
                "twitch_username": "example",
                "twitch_user_id": 43242
            }
        ]
    }
}
```