### PR TITLE
Update Twitch Usernames

### DIFF
--- a/API/classes/twitch_management.py
+++ b/API/classes/twitch_management.py
@@ -78,6 +78,10 @@ class twitch_management(object):
         else:
             return({"status":"error", "code":503, "message":"Error removing notification!"})
 
+    def update_user(self, twitch_user_id, twitch_display_name):
+        # Used to updated twitch_usernames
+        sql = "UPDATE `twitch_channels` SET `twitch_username` = %s WHERE `twitch_user_id` = %s"
+        db_status = self.db.update(sql, [twitch_display_name, twitch_user_id])
 
 
 class twitch_handler(object):
@@ -114,7 +118,7 @@ class twitch_handler(object):
 
             data = {"hub.mode":mode.lower(),
                 "hub.topic":str("https://api.twitch.tv/helix/streams?user_id=" + twitch_user_id),
-                "hub.callback":str(os.getenv('WEBHOOK_CALLBACK') + "/" + twitch_user_id),
+                "hub.callback":str(os.getenv('API_URL') + "/twitch/callback/streams/" + twitch_user_id),
                 "hub.lease_seconds":"864000",
                 "hub.secret":"top_secret",}
 

--- a/API/main.py
+++ b/API/main.py
@@ -18,7 +18,8 @@ from routes.test            import test
 # Twitch API routes
 from routes.twitch.add      import twitch_add
 from routes.twitch.delete   import twitch_delete
-from routes.twitch.callback import twitch_callback
+from routes.twitch.callback.streams import twitch_callback_streams
+from routes.twitch.callback.users   import twitch_callback_users
 import routes.twitch.metrics as metrics
 
 # YouTube API routes
@@ -49,8 +50,8 @@ class public_facing_api(object):
         self.routes = [
             {'route':'/twitch/manage/add',                  'class': twitch_add()},
             {'route':'/twitch/manage/delete',               'class': twitch_delete()},
-            {'route':'/twitch/callback',                    'class': twitch_callback()},
-            {'route':'/twitch/callback/{twitch_user_id}',   'class': twitch_callback()},
+            {'route':'/twitch/callback/streams/{twitch_user_id}',   'class': twitch_callback_streams()},
+            {'route':'/twitch/callback/users/{twitch_user_id}',     'class': twitch_callback_users()},
             {'route':'/twitch/metrics/{twitch_username}',   'class': metrics.twitch_metrics_username()},
             {'route':'/twitch/metrics/id/{twitch_user_id}', 'class': metrics.twitch_metrics_id()},
             {'route':'/youtube/callback', 'class': youtube_callback()},

--- a/API/routes/twitch/callback/streams.py
+++ b/API/routes/twitch/callback/streams.py
@@ -12,10 +12,10 @@
 #
 #               In some cases, Twitch will send multiple notifications about a
 #               single live stream. This class attempts to mitigate sending the
-#               same notifcation multiple times.
+#               same notification multiple times.
 
 # Related Routes:
-# - /twitch/callback/{twitch_user_id}
+# - /twitch/callback/streams/{twitch_user_id}
 
 import falcon
 import json
@@ -24,7 +24,7 @@ from classes.discord_post import discord_post
 from classes.data_handler import data_handler
 from classes.twitch.stream_metrics import stream_metrics
 
-class twitch_callback(object):
+class twitch_callback_streams(object):
     def __init__(self):
         pass
 

--- a/API/routes/twitch/callback/users.py
+++ b/API/routes/twitch/callback/users.py
@@ -1,0 +1,32 @@
+# Author: @Travis-Owens
+# Date: 2021-01-13
+# Desc: This route is used to recieve notifications about changes to the 'helix/users' endpoint.
+#        Currently only the "twitch_username" field is tracked in the database.
+
+import falcon
+import json
+
+from classes.twitch_management import twitch_management
+
+class twitch_callback_users(object):
+    def __init__(self):
+        pass
+
+    def on_get(self, req, resp, twitch_user_id=None):
+        # Respond to challenge
+        resp.status = falcon.HTTP_200   # Set response type
+        resp.content_type = ['application/json']    # Set content_type
+        resp.body = req.params['hub.challenge'] # Body of response
+
+    def on_post(self, req, resp, twitch_user_id):
+
+        try:
+            data = json.loads(req.bounded_stream.read().decode())
+
+            if 'display_name' in data['data'][0]:
+                twitch_display_name = data['data'][0]['display_name']
+                twitch_management(twitch_display_name,0,0).update_user(twitch_user_id, twitch_display_name)
+
+
+        except Exception as e:
+            resp.body = str(e)

--- a/crontab/cron_run.py
+++ b/crontab/cron_run.py
@@ -9,14 +9,12 @@ import requests
 from twitch_oauth import twitch_oauth
 from twitch_subscribe import twitch_subscribe
 from youtube_subscribe import youtube_subscribe
-from cron_test import cron_test
 
 while True:
     try:
-        # cron_test()
-        twitch_oauth()
-        twitch_subscribe()
-        youtube_subscribe()
-        sleep(60*60)
+        twitch_oauth()                  # Updates the oauth token for the Twitch API
+        twitch_subscribe()              # Resubscribes to Twitch webhook 'helix/streams' and 'helix/users' events
+        youtube_subscribe()             # Resubscribes to YouTube webhook events
+        sleep(60*60*23)                 # 82,800 seconds (23 hours)
     except Exception as e:
         print(e)

--- a/crontab/cron_test.py
+++ b/crontab/cron_test.py
@@ -1,5 +1,0 @@
-import requests
-
-class cron_test(object):
-    def __init__(self):
-        requests.get("")

--- a/crontab/youtube_subscribe.py
+++ b/crontab/youtube_subscribe.py
@@ -44,7 +44,7 @@ class youtube_subscribe(object):
             # Currently, no headers are required.
             headers= {}
 
-            # TODO: Figure out a better solution
+            # NOTE: Figure out a better solution
             # timeout =1.xx is 100% a hack. Falcon only supports a single simultaneous
             # connection, the pubsubhubbub attemtps to reach /youtube/callback, however,
             # this current API request is blocking Falcon from responding.
@@ -52,11 +52,7 @@ class youtube_subscribe(object):
             # and that the pubsubhubbub is able to reach the callback.
             response = requests.post(url, headers=headers, data = payload, timeout=1.0000000001)
 
-            print(response.content)
-            return(True)
-
         except requests.exceptions.ReadTimeout:
-            print("timeout")
             return(True)
         except Exception as e:
             print("manage_webhook_subscription: " + str(e))
@@ -78,5 +74,3 @@ class youtube_subscribe(object):
                                      db=os.getenv('DB_NAME').strip("\r"),
                                      charset='utf8mb4',
                                      cursorclass=pymysql.cursors.DictCursor))
-
-youtube_subscribe()


### PR DESCRIPTION
Implemented webhook subscription to Twitch API endpoint 'helix/users', this subscription will send a POST requests to '/twitch/callback/users/{twitch_user_id}' when changes are made to a Twitch channel. This webhook event is used to update column `twitch_username` in table `twitch_channels`.

Created new API routes:
- '/twitch/callback/streams/{twitch_user_id}'
- '/twitch/callback/users/{twitch_user_id}'

Moved:
'/twitch/callback/{twitch_user_id}' -> '/twitch/callback/streams/{twitch_user_id}'

#49 