### PR TITLE
Handle Deleted Discord Guilds and Channels

### DIFF
--- a/API/classes/discord_post.py
+++ b/API/classes/discord_post.py
@@ -8,10 +8,12 @@ import os
 import random
 import string
 
+from classes.notifications import notifications
+
 class discord_post(object):
     def __init__(self):
         self.headers = { "Authorization":"Bot {}".format(os.getenv('DISCORD_BOT_TOKEN').strip("\r")),
-                        "User-Agent":"KeshBotics (vahkesh.com, v2.1)",
+                        "User-Agent":"KeshBotics (v3.3)",
                         "Content-Type":"application/json", }
 
     def post_message(self, message, discord_channel_ids):
@@ -20,6 +22,12 @@ class discord_post(object):
         for channel_id in discord_channel_ids:
             discord_message_url = "https://discordapp.com/api/channels/{}/messages".format(channel_id)
             r = requests.post(discord_message_url, headers = self.headers, data = json_data)
+
+            if(r.status_code == 404 and r.json()['message'] == "Unknown Channel"):
+                # Discord channel no longer exist, delete notifications associated
+                # with the discord_channel_id
+                notifications().delete_by_discord_channel_id(channel_id)
+
 
     def prepare_twitch_message(self, twitch_username, twitch_thumbnail_url):
         twitch_channel_url = 'https://twitch.tv/' + twitch_username
@@ -40,7 +48,7 @@ class discord_post(object):
                   "text": "KeshBotics"
                 },
                 "thumbnail": {
-                  "url": "https://cdn.discordapp.com/avatars/368199725771390977/c9d101f88d0951730b482c5dcc45f075.png?size=256"
+                  "url": "https://cdn.discordapp.com/avatars/532575955324239882/653f3b3749c3da11947a70881d675160.png?size=256"
                 },
                 "image": {
                   "url": twitch_channel_preview_url
@@ -48,7 +56,7 @@ class discord_post(object):
                 "author": {
                   "name": "KeshBotics",
                   "url": "https://discordapp.com",
-                  "icon_url": "https://cdn.discordapp.com/avatars/368199725771390977/c9d101f88d0951730b482c5dcc45f075.png?size=256"
+                  "icon_url": "https://cdn.discordapp.com/avatars/532575955324239882/653f3b3749c3da11947a70881d675160.png?size=256"
                 },
                 "fields": [
                           {

--- a/API/classes/notifications.py
+++ b/API/classes/notifications.py
@@ -45,3 +45,25 @@ class notifications(object):
             return(None)
 
         return(youtube_channel_ids)
+
+    def delete_by_discord_channel_id(self, discord_channel_id):
+        # Delete notifications associated with the given discord_channel_id
+
+        # Delete from `twitch_notifications`
+        sql = "DELETE FROM `twitch_notifications` WHERE `discord_channel_id` = %s"
+        self.db.delete(sql, [discord_channel_id])
+
+        # Delete from `youtube_notifications`
+        sql = "DELETE FROM `youtube` WHERE `disc_channel_id` =  %s"
+        self.db.delete(sql, [discord_channel_id])
+
+    def delete_by_discord_guild_id(self, discord_guild_id):
+        # Delete notifications associated with the given discord_guild_id
+
+        # Delete from `twitch_notifications`
+        sql = "DELETE FROM `twitch_notifications` WHERE `discord_guild_id` = %s"
+        self.db.delete(sql, [discord_guild_id])
+
+        # Delete from `youtube_notifications`
+        sql = "DELETE FROM `youtube` WHERE `disc_guild_id` = %s"
+        self.db.delete(sql, [discord_guild_id])

--- a/API/classes/youtube/youtube_notification.py
+++ b/API/classes/youtube/youtube_notification.py
@@ -87,7 +87,7 @@ class youtube_notification(object):
                 "color": 9442302,
                 "timestamp": "",
                 "footer": {
-                  "icon_url": "https://cdn.discordapp.com/avatars/368199725771390977/c9d101f88d0951730b482c5dcc45f075.png?size=256",
+                  "icon_url": "https://cdn.discordapp.com/avatars/532575955324239882/653f3b3749c3da11947a70881d675160.png?size=256",
                   "text": "KeshBotics"
                 },
                 "thumbnail": {
@@ -99,7 +99,7 @@ class youtube_notification(object):
                 "author": {
                   "name": yt_video_author,
                   "url": "https://www.youtube.com/watch?v=" + yt_video_id,
-                  "icon_url": "https://cdn.discordapp.com/avatars/368199725771390977/c9d101f88d0951730b482c5dcc45f075.png?size=256"
+                  "icon_url": "https://cdn.discordapp.com/avatars/532575955324239882/653f3b3749c3da11947a70881d675160.png?size=256"
                 },
                 "fields": [
                           {

--- a/API/routes/notifications/notifications.py
+++ b/API/routes/notifications/notifications.py
@@ -21,7 +21,7 @@ class get_notificaitons(object):
             if discord_channel_id is None:
                 raise falcon.HTTPBadRequest('Missing Requried Headers', 'Required header(s): discord-channel-id')
 
-            # Create object for notificaions class, get notification data for twitch and youtube
+            # Create object for notifications class, get notification data for twitch and youtube
             # If no notifications are found, type None will be returned
             notifications_obj = notifications()
             twitch_notifications  = notifications_obj.get_twitch_notifications(discord_channel_id)
@@ -47,6 +47,30 @@ class get_notificaitons(object):
 
         except Exception as e:
             message = {"status":"error", "code":400, "message":'API ERROR'}
+            resp.status = falcon.get_http_status(message['code'])
+            resp.content_type = ['application/json']
+            resp.body = json.dumps(message)
+
+    def on_delete(self, req, resp):
+        # Used to delete notifications associated with either a discord_channel_id
+        # or a discord_guild_id
+        try:
+            # Check if discord-channel-id or discord-guild-id is in the headers, else HTTPBadRequest
+            if req.get_header('discord-channel-id') is not None:
+                notifications().delete_by_discord_channel_id(req.get_header('discord-channel-id'))
+
+            elif req.get_header('discord-guild-id') is not None:
+                notifications().delete_by_discord_guild_id(req.get_header('discord-guild-id'))
+
+            else:
+                raise falcon.HTTPBadRequest('Missing Requried Headers', 'Required header(s): discord-channel-id or discord-guild-id')
+
+            resp.status = falcon.get_http_status(200)
+            resp.content_type = ['application/json']
+            resp.body = json.dumps({"status":"success", "code":200})
+
+        except falcon.HTTPBadRequest as e:
+            message = {"status":"error", "code":400, "message":e.description}
             resp.status = falcon.get_http_status(message['code'])
             resp.content_type = ['application/json']
             resp.body = json.dumps(message)

--- a/discord_async/cogs/events.py
+++ b/discord_async/cogs/events.py
@@ -1,0 +1,28 @@
+# Author: @Travis-Owens
+# Date: 2021-01-17
+# Desc: This cog uses the "discord.on_guild_channel_delete"  and
+#         "discord.on_guild_remove" events to detect channel/guild deletions.
+#          A request is made to the API to delete notifications associated with
+#          either the Discord Guild ID or the Discord Channel ID
+
+
+import discord
+import os
+import requests
+
+from discord.ext import commands
+
+class events(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.Cog.listener()
+    async def on_guild_remove(self, guild):
+        r = requests.delete(url=str(os.getenv("API_URL") + "/notifications"), headers={'auth':os.getenv("API_AUTH_CODE"), 'discord-guild-id':str(guild.id)})
+
+    @commands.Cog.listener()
+    async def on_guild_channel_delete(self, channel):
+        r = requests.delete(url=str(os.getenv("API_URL") + "/notifications"), headers={'auth':os.getenv("API_AUTH_CODE"), 'discord-channel-id':str(channel.id)})
+
+def setup(bot):
+    bot.add_cog(events(bot))

--- a/discord_async/main.py
+++ b/discord_async/main.py
@@ -34,7 +34,8 @@ extensions = [  'cogs.owner',
                 'cogs.purge',
                 'cogs.error_handling',
                 'cogs.help',
-                'cogs.list'
+                'cogs.list',
+                'cogs.events'
                 ]
 
 # Load the cogs


### PR DESCRIPTION
Implemented 2 methods of detecting deleted Discord channels and 1 method of detecting deleted discord guilds.

Detect Deleted Discord Channels:
- Async  - 'on_guild_channel_delete' listener
- discord_post - If response status code is '404' and message is "Unknown Channel"

Detect Deleted Discord Guilds:
- Async - 'on_guild_remove' listener

API Routes:
- DELETE '/notifications'
-- Accepts either 'discord-channel-id' or 'discord-guild-id' header
-- Requires 'auth' header
-- Uses the notifications class to delete entries based on provided header

Unrelated to issue; Updated the avatar links. This should be handled differently.

Resolves #4 