### PR TITLE
YouTube Data Revamp

### DIFF
--- a/API/classes/notifications.py
+++ b/API/classes/notifications.py
@@ -23,7 +23,7 @@ class notifications(object):
         # Flatten the twitch_user_ids dict into a list
         twitch_user_ids = list(map(lambda x : x['twitch_user_id'], twitch_user_ids))
 
-        # Get Twitch Usernames
+        # Get Twitch Usernames, associated with the list of twitch_user_ids
         sql = "SELECT `twitch_user_id`, `twitch_username` FROM `twitch_channels` WHERE `twitch_user_id` IN (%s)"
         # Inserts a '%s' for each element in the twitch_user_ids list
         sql = sql % ','.join(['%s'] * len(twitch_user_ids))
@@ -35,10 +35,20 @@ class notifications(object):
 
     def get_youtube_notifications(self, discord_channel_id):
         # Return format:
-        # [{'youtube_channel_id':x}, ...]
+        # [{'youtube_channel_id':x, 'youtube_display_name':y}, ...]
 
-        # Get YouTube Channel IDs
-        sql = "SELECT `yt_channel_id` as 'youtube_channel_id' FROM `youtube_notifications` WHERE `discord_channel_id` = %s"
+        # SQL query to select yt_channel_id from the youtube_notifications channelc
+        #  where discord_channel_id equals the given, join with the youtube_channels
+        #  table on value yt_channel_id (used to match the yt_display_name).
+        sql = (
+                "SELECT youtube_notifications.yt_channel_id as 'youtube_channel_id', "
+                      "youtube_channels.yt_display_name as 'youtube_display_name' "
+                 "FROM youtube_notifications "
+                 "INNER JOIN youtube_channels "
+                 "ON youtube_notifications.yt_channel_id = youtube_channels.yt_channel_id "
+                 "AND youtube_notifications.discord_channel_id = %s"
+            )
+
         youtube_channel_ids = self.db.select(sql, [discord_channel_id])
 
         if(len(youtube_channel_ids) == 0):

--- a/API/classes/notifications.py
+++ b/API/classes/notifications.py
@@ -38,7 +38,7 @@ class notifications(object):
         # [{'youtube_channel_id':x}, ...]
 
         # Get YouTube Channel IDs
-        sql = "SELECT `yt_channel_id` as 'youtube_channel_id' FROM `youtube` WHERE `disc_channel_id` = %s"
+        sql = "SELECT `yt_channel_id` as 'youtube_channel_id' FROM `youtube_notifications` WHERE `discord_channel_id` = %s"
         youtube_channel_ids = self.db.select(sql, [discord_channel_id])
 
         if(len(youtube_channel_ids) == 0):
@@ -54,7 +54,7 @@ class notifications(object):
         self.db.delete(sql, [discord_channel_id])
 
         # Delete from `youtube_notifications`
-        sql = "DELETE FROM `youtube` WHERE `disc_channel_id` =  %s"
+        sql = "DELETE FROM `youtube_notifications` WHERE `discord_channel_id` =  %s"
         self.db.delete(sql, [discord_channel_id])
 
     def delete_by_discord_guild_id(self, discord_guild_id):
@@ -65,5 +65,5 @@ class notifications(object):
         self.db.delete(sql, [discord_guild_id])
 
         # Delete from `youtube_notifications`
-        sql = "DELETE FROM `youtube` WHERE `disc_guild_id` = %s"
+        sql = "DELETE FROM `youtube_notifications` WHERE `discord_guild_id` = %s"
         self.db.delete(sql, [discord_guild_id])

--- a/API/classes/youtube/youtube_management.py
+++ b/API/classes/youtube/youtube_management.py
@@ -180,24 +180,24 @@ class youtube_management(object):
         # will return the data in a dictionary format (the raw snippet data). If a string is passed, this
         # function will only return the channel's display name (string).
 
-        if type(yt_channel_id) is list:
+        if isinstance(yt_channel_id, list):
             # convert list into string with values seperated by a comma
             # /youtube/v3/channels endpoint supports using a list of channel IDs.
-            id = ",".join(yt_channel_id)
+            channel_id = ",".join(yt_channel_id)
         else:
-            id = yt_channel_id
+            channel_id = yt_channel_id
 
         try:
             # Use the Google API to retreive the 'snippet' for the provided yt_channel_id
-            data = requests.get("https://www.googleapis.com/youtube/v3/channels?part=snippet&id=" + id + "&key=" + os.getenv('GCP_API_KEY').strip("\r"))
+            data = requests.get("https://www.googleapis.com/youtube/v3/channels?part=snippet&id=" + channel_id + "&key=" + os.getenv('GCP_API_KEY').strip("\r"))
             data = json.loads(data.content.decode('utf-8'))
 
-            if type(yt_channel_id) is list:
+            if isinstance(yt_channel_id, list):
                 # Return the snippet data for all requested channel IDs
                 return(data)
-            else:
-                # Return the string value of the 'title' field
-                return(data['items'][0]['snippet']['title'])
+
+            # Else, return the string value of the 'title' field (single yt_channel_id in argument)
+            return(data['items'][0]['snippet']['title'])
 
         except Exception as e:
             # Failed to retreive the youtube channel name

--- a/API/classes/youtube/youtube_notification.py
+++ b/API/classes/youtube/youtube_notification.py
@@ -73,8 +73,8 @@ class youtube_notification(object):
         values  = [yt_channel_id]
         data    = data_handler().select(sql, values)
 
-        # Flatten the dict to only the keys (disc_channel_id)
-        return(list(map(lambda x : x['disc_channel_id'], data)))
+        # Flatten the dict to only the keys (discord_channel_id)
+        return(list(map(lambda x : x['discord_channel_id'], data)))
 
     def prepare_discord_message(self, yt_video_id, yt_video_author, yt_video_title):
         # Embeded message for Discord

--- a/API/classes/youtube/youtube_notification.py
+++ b/API/classes/youtube/youtube_notification.py
@@ -69,7 +69,7 @@ class youtube_notification(object):
     def get_discord_channel_ids(self, yt_channel_id):
         # This function will search the databse for discord_channel_ids that have subscribed to yt_channel_id
 
-        sql     = "SELECT `disc_channel_id` FROM `youtube` WHERE `yt_channel_id` = %s"
+        sql     = "SELECT `discord_channel_id` FROM `youtube_notifications` WHERE `yt_channel_id` = %s"
         values  = [yt_channel_id]
         data    = data_handler().select(sql, values)
 

--- a/API/main.py
+++ b/API/main.py
@@ -26,6 +26,7 @@ import routes.twitch.metrics as metrics
 from routes.youtube.callback import youtube_callback
 from routes.youtube.add      import youtube_add
 from routes.youtube.delete   import youtube_delete
+from routes.youtube.update   import youtube_update
 
 # Twitter API routes
 from routes.twitter.callback import twitter_callback
@@ -57,6 +58,7 @@ class public_facing_api(object):
             {'route':'/youtube/callback', 'class': youtube_callback()},
             {'route':'/youtube/manage/add',     'class': youtube_add()},
             {'route':'/youtube/manage/delete',  'class': youtube_delete()},
+            {'route':'/youtube/update',         'class': youtube_update()},
             {'route':'/test',   'class': test()},
             {'route':'/notifications',   'class': get_notificaitons()},
             {'route':'/twitter/callback', 'class': twitter_callback()},

--- a/API/routes/youtube/update.py
+++ b/API/routes/youtube/update.py
@@ -1,0 +1,32 @@
+# Author: @Travis-Owens
+# Date: 2021-01-18
+# Desc: This is used to trigger the API to update the webhook (pubsubhubbub)
+#        subcriptions and YouTube display names in the database.
+
+import falcon
+import os
+import json
+
+from middleware.auth import auth
+from classes.youtube.youtube_management import youtube_management
+
+@falcon.before(auth())
+class youtube_update(object):
+    def __init__(self):
+        pass
+
+    def on_put(self, req, resp):
+
+        try:
+            yt_management = youtube_management()
+            yt_management.update_display_names()
+            yt_management.update_webhook_subs()
+
+            resp.status = falcon.get_http_status(200)
+            resp.content_type = ['application/json']
+            resp.body = json.dumps({"status":"success", "code":200})
+
+        except Exception as e:
+            resp.status = falcon.get_http_status(400)
+            resp.content_type = ['application/json']
+            resp.body = json.dumps({"status":"error", "code":400})

--- a/crontab/cron_run.py
+++ b/crontab/cron_run.py
@@ -10,6 +10,9 @@ from twitch_oauth import twitch_oauth
 from twitch_subscribe import twitch_subscribe
 from youtube_subscribe import youtube_subscribe
 
+# Wait for API to start
+sleep(30)
+
 while True:
     try:
         twitch_oauth()                  # Updates the oauth token for the Twitch API

--- a/crontab/youtube_subscribe.py
+++ b/crontab/youtube_subscribe.py
@@ -8,12 +8,15 @@ import requests
 
 class youtube_subscribe(object):
     def __init__(self):
-        # A list of unique YouTube channel IDs from the database
-        youtube_channel_ids = self.get_channel_ids()
+        # # A list of unique YouTube channel IDs from the database
+        # youtube_channel_ids = self.get_channel_ids()
+        #
+        # # Iterate over the list of channel IDs and re-subscribe to the webhook
+        # for channel_id in youtube_channel_ids:
+        #     self.manage_webhook_subscription("subscribe", channel_id['yt_channel_id'])
 
-        # Iterate over the list of channel IDs and re-subscribe to the webhook
-        for channel_id in youtube_channel_ids:
-            self.manage_webhook_subscription("subscribe", channel_id['yt_channel_id'])
+        # Moved to API 2021-01-18
+        r = requests.put(str(os.getenv("API_URL") + '/youtube/update'), headers={'auth':os.getenv('API_AUTH_CODE')}, data={} )
 
     def get_channel_ids(self):
         sql = "SELECT DISTINCT `yt_channel_id` FROM `youtube`"

--- a/database/tables/youtube_channels.sql
+++ b/database/tables/youtube_channels.sql
@@ -23,22 +23,23 @@ SET time_zone = "+00:00";
 -- --------------------------------------------------------
 
 --
--- Table structure for table `youtube_submissions`
+-- Table structure for table `youtube_channels`
 --
 
-CREATE TABLE `youtube_submissions` (
+CREATE TABLE `youtube_channels` (
   `id` int(11) NOT NULL,
-  `yt_video_id` text COLLATE utf8_bin NOT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+  `yt_channel_id` text COLLATE utf8mb4_bin NOT NULL,
+  `yt_display_name` text COLLATE utf8mb4_bin NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 
 --
 -- Indexes for dumped tables
 --
 
 --
--- Indexes for table `youtube_submissions`
+-- Indexes for table `youtube_channels`
 --
-ALTER TABLE `youtube_submissions`
+ALTER TABLE `youtube_channels`
   ADD PRIMARY KEY (`id`);
 
 --
@@ -46,9 +47,9 @@ ALTER TABLE `youtube_submissions`
 --
 
 --
--- AUTO_INCREMENT for table `youtube_submissions`
+-- AUTO_INCREMENT for table `youtube_channels`
 --
-ALTER TABLE `youtube_submissions`
+ALTER TABLE `youtube_channels`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
 /*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;

--- a/database/tables/youtube_notifications.sql
+++ b/database/tables/youtube_notifications.sql
@@ -23,12 +23,14 @@ SET time_zone = "+00:00";
 -- --------------------------------------------------------
 
 --
--- Table structure for table `youtube_submissions`
+-- Table structure for table `youtube_notifications`
 --
 
-CREATE TABLE `youtube_submissions` (
+CREATE TABLE `youtube_notifications` (
   `id` int(11) NOT NULL,
-  `yt_video_id` text COLLATE utf8_bin NOT NULL
+  `yt_channel_id` text COLLATE utf8_bin NOT NULL,
+  `discord_guild_id` text COLLATE utf8_bin,
+  `discord_channel_id` text COLLATE utf8_bin NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
 --
@@ -36,9 +38,9 @@ CREATE TABLE `youtube_submissions` (
 --
 
 --
--- Indexes for table `youtube_submissions`
+-- Indexes for table `youtube_notifications`
 --
-ALTER TABLE `youtube_submissions`
+ALTER TABLE `youtube_notifications`
   ADD PRIMARY KEY (`id`);
 
 --
@@ -46,9 +48,9 @@ ALTER TABLE `youtube_submissions`
 --
 
 --
--- AUTO_INCREMENT for table `youtube_submissions`
+-- AUTO_INCREMENT for table `youtube_notifications`
 --
-ALTER TABLE `youtube_submissions`
+ALTER TABLE `youtube_notifications`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
 /*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;

--- a/discord_async/cogs/list.py
+++ b/discord_async/cogs/list.py
@@ -87,7 +87,7 @@ class notification_strings(object):
 
         youtube_str = ''
         for channel in youtube_channels:
-            youtube_str += str("https://youtube.com/channel/" + channel['youtube_channel_id'] + "\n")
+            youtube_str += str("[" + channel["youtube_display_name"] + "](https://youtube.com/channel/" + channel['youtube_channel_id'] + ")\n")
 
         youtube_str += "Remove a YouTube notification: ```k!youtube del <YouTube channel URL>```\n"
         youtube_str += "\n\n"


### PR DESCRIPTION
**YouTube Database Refactor**

Refactored Naming in YouTube related tables:
- 'disc_channel_id' -> 'discord_channel_id'
- 'disc_guild_id' -> 'discord_guild_id'

- Reflected name changes in source
- Updated SQL schemas


**Implemented Display Name Updating for YouTube Channels**

Implemented a method of updating the YouTube display name field in the database ('youtube_channels'). This value is used for creating a list of notifications in route '/notifications' and command '!list'. In addition to being updated routinely, the YouTube display name will be added to the 'youtube_channels' table when a new channel is added to the DB.
This update is triggered via a PUT request to the API: '/youtube/update'

The "cron" task no longer handles the code for updating the YouTube tables and webhook subscriptions. It instead creates a PUT requests to the API route '/youtube/update'. This begins to eliminate some of the current segmentation between the "cron" and "API" modules.

Additionally, added a 30 second sleep to the beginning of “cron_run.py”. This was added to ensure that the API has had adequate time to start.

Resolves: #52 


**Updated get_youtube_notifications**

Updated the function: "get_youtube_notifications()" in class "notifications”

These changes reflect the addition of the "yt_display_name" field added to the "youtube_channels” table. The SQL queries were optimized and reduced to a single query that joins the "yt_display_name" to the rows selected in "youtube_notifications". This eliminates the need to flatten the initial query into a list using the lambda function.

Also updated the list command to show the channel display name with a hyperlink to the channel instead of just a link.
